### PR TITLE
Replace default app display name and minor fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
@@ -21,16 +21,17 @@ import sys
 import os
 
 class ExecuteAction(Application):
-    
+
     def init_app(self):
         deny_permissions = self.get_setting("deny_permissions")
         deny_platforms = self.get_setting("deny_platforms")
-        
+
         p = {
             "title": self.get_setting("display_name"),
             "deny_permissions": deny_permissions,
             "deny_platforms": deny_platforms,
-            "supports_multiple_selection": self.get_setting("supports_multiple_selection")
+            "supports_multiple_selection": \
+                self.get_setting("supports_multiple_selection")
         }
 
         app_identifier = self.get_setting("display_name")
@@ -39,14 +40,17 @@ class ExecuteAction(Application):
 
 
     def process_action(self, entity_type=None, entity_ids=None):
-        
+
         entities = None
 
         if entity_type and entity_ids:
-            self.log_debug("Processing %s %s" % (len(entity_ids), entity_type))
-        
+            self.log_debug("Processing {0} {1}" \
+                    .format((len(entity_ids), entity_type)))
+
             if entity_type not in self.get_setting("allowed_entities"):
-                self.log_info("Sorry, this app only works with entities of type %s." % self.get_setting("allowed_entities"))
+                self.log_info(("Sorry, this app only works with entities "
+                               "of type {0}.") \
+                    .format(self.get_setting("allowed_entities")))
                 return
 
             entity_fields_dict = self.shotgun.schema_field_read(entity_type)
@@ -61,30 +65,39 @@ class ExecuteAction(Application):
                 for field in extra_fields[entity_type]:
                     shotgun_fields.append(field)
 
-            entities = self.shotgun.find(entity_type, [["id", "in", entity_ids]], shotgun_fields)
+            entities = self.shotgun.find(
+                entity_type,
+                [["id", "in", entity_ids]],
+                shotgun_fields
+            )
 
         try:
-            result = self.execute_hook("action_hook", 
-                                       entity_type=entity_type,
-                                       entities=entities,
-                                       other_params=self.get_setting("other_params"))
+            result = self.execute_hook(
+                "action_hook",
+                entity_type=entity_type,
+                entities=entities,
+                other_params=self.get_setting("other_params")
+            )
 
         except:
-            e = traceback.format_exc()
-            self.log_error("Failed to process the action for this %s:\n%s" % (entity_type, e))
+            error = traceback.format_exc()
+            self.log_error("Failed to process the action for this {0}:\n{1}" \
+                .format(entity_type, error))
             return
 
 
-        message = "There were succesfully executed action for %s %s." % (len(result['succes']), entity_type)
+        message = "There were {0} succesfully executed actions for {1}." \
+            .format(len(result['succes']), entity_type)
 
         if len(result['messages']) != 0:
-            message += "\n\nThe followin messages were returned from the action:\n"
+            message += "\n\nThe following messages were returned from the action:\n"
             for msg in result['messages']:
-                message += "%s\n" % msg
+                message += "{0}\n".format(msg)
 
         if len(result['errors']) != 0:
-            message += "\n\nThere were errors for %s %s, details:" % len(result['errors'], entity_type)
+            message += "\n\nThere were {0} errors for {1}, details:" \
+                .format(len(result['errors']), entity_type)
             for er in result['errors']:
-                message += "%s\n" % er
+                message += "{0}\n".format(er)
 
         self.log_info(message)

--- a/hooks/shotgun_execute_action_hook.py
+++ b/hooks/shotgun_execute_action_hook.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
@@ -17,12 +17,11 @@ from tank import TankError
 import os
 
 class ExecuteActionHook(Hook):
-    
-    
+
     def execute(self, entity_type, entities, other_params, **kwargs):
         """
         Executes an action for the selected entities.
-        
+
         :param entity_type: ...
         :param entities: ...
         :param other_params: ...
@@ -32,4 +31,8 @@ class ExecuteActionHook(Hook):
 
         self.parent.log_debug("Executing hook...")
 
-        return {'succes': entities, 'errors': [], 'messages': ['Empty Action, no process were made to any entity']}
+        return {
+            'succes': entities,
+            'errors': [],
+            'messages': ['Empty Action, no process were made to any entity']
+        }

--- a/info.yml
+++ b/info.yml
@@ -1,11 +1,11 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 # Metadata defining the behaviour and requirements for this app
@@ -54,18 +54,18 @@ configuration:
         type: list
         values: {type: shotgun_permission_group}
         allows_empty: True
-        description: An optional parameter which lets you limit the visibility of this app. 
-                     If you for example put in ['Artist'] as the value for this parameter, 
-                     any user belonging to the shotgun permissions group Artist will not be 
+        description: An optional parameter which lets you limit the visibility of this app.
+                     If you for example put in ['Artist'] as the value for this parameter,
+                     any user belonging to the shotgun permissions group Artist will not be
                      able to see or execute the App.
 
     deny_platforms:
         type: list
         values: {type: str}
         allows_empty: True
-        description: An optional parameter which lets you turn off this app on certain platforms. 
-                     If you don't want it to appear on the Shotgun Pipeline Toolkit action menu 
-                     for a platform, just include it in the the deny_platforms list. Valid values 
+        description: An optional parameter which lets you turn off this app on certain platforms.
+                     If you don't want it to appear on the Shotgun Pipeline Toolkit action menu
+                     for a platform, just include it in the the deny_platforms list. Valid values
                      are Windows, Mac and Linux.
 
 
@@ -73,9 +73,9 @@ configuration:
 requires_shotgun_fields:
 
 
-# More verbose description of this item 
-display_name: "Update Published File Checksum"
-description: "Rebuild of checksum for the selected publishes. "
+# More verbose description of this item
+display_name: "SG Execute Actions"
+description: "Run SG execute actions"
 
 # Required minimum versions for this item to run
 requires_shotgun_version:


### PR DESCRIPTION
Minor fixes are mainly replacing the string formating method, adding line breaks, and removing trailing spaces.

There's also a syntax fix in app.py line 86: replaced `len(result['errors'], entity_type)` with `(len(result['errors']), entity_type)` (missing parenthesis for len function)