### PR TITLE
Fix string formatting

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,7 +45,7 @@ class ExecuteAction(Application):
 
         if entity_type and entity_ids:
             self.log_debug("Processing {0} {1}" \
-                    .format((len(entity_ids), entity_type)))
+                .format(len(entity_ids), entity_type))
 
             if entity_type not in self.get_setting("allowed_entities"):
                 self.log_info(("Sorry, this app only works with entities "


### PR DESCRIPTION
The string formating is expecting two values, but instead, a single tuple was provided.  Aparently this is causing the web "ensure file is local" action to fail.